### PR TITLE
jenkinsx-python-quickstart to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,6 +7,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.89
+- name: jenkinsx-python-quickstart
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1
 - name: jenkinsx-test2
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.3


### PR DESCRIPTION
Promote jenkinsx-python-quickstart to version 0.0.1